### PR TITLE
Using my own fork of mkdocs_puml to stabilize PlantUML diagram generation

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 mkdocs-material[recommended,imaging]
 mkdocstrings-python
 
-mkdocs_puml
+git+https://github.com/VenetianMasquerade/mkdocs_puml.git@feat/request-retries
 
 griffe


### PR DESCRIPTION
# Pull Request

Fixes #34 

## Description

Use my fork of `mkdocs_puml` to stabilize PlantUML diagram generation.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Checklist
- [x] Documentation updated