### PR TITLE
#87 enforce station name to be at least 1 char via the db schema

### DIFF
--- a/backend/app/schemas/station.py
+++ b/backend/app/schemas/station.py
@@ -1,8 +1,8 @@
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class StationBase(BaseModel):
-	name: str
+	name: str = Field(min_length=1)
 	description: str | None = None
 
 


### PR DESCRIPTION
# Pull Request

Fixes #87

## Description
Configured the db schema to require the station name to be not empty.

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] Code compiles
- [x] No new warnings added to code base
- [x] Existing tests are green
- [x] Tests added
- [x] Code is commented where necessary