### PR TITLE
Feature/#248 add backend pen tests

### DIFF
--- a/backend/tests/test_pentest.py
+++ b/backend/tests/test_pentest.py
@@ -1,0 +1,63 @@
+from app.main import app
+
+class TestRouteClassification:
+    PREFIX = "/api/v0"
+
+    PUBLIC_ENDPOINTS = {
+        ("GET", "/"),
+        ("GET", "/redoc"),
+        ("GET", "/docs"),
+        ("GET", "/health"),
+        ("GET", PREFIX+ "/auth"),
+        ("POST", PREFIX+ "/auth/register"),
+        ("POST", PREFIX+ "/auth/jwt/login"),
+        ("POST", PREFIX+ "/auth/jwt/register"),
+        ("GET", PREFIX+ "/docs"),
+        ("GET", "/docs/oauth2-redirect"),
+    }
+
+    PROTECTED_ENDPOINTS = {
+        ("GET", PREFIX+ "/export/json"),
+        ("GET", PREFIX+ "/export/csv"),
+        ("GET", PREFIX+ "/fillings"),
+        ("POST", PREFIX+ "/fillings/create"),
+        ("DELETE", PREFIX+ "/fillings/delete"),
+        ("GET", PREFIX+ "/stations/"),
+        ("GET", PREFIX+ "/stations/nearby"),
+        ("GET", PREFIX+ "/users/me"),
+        ("PATCH", PREFIX+ "/users/me"),
+        ("GET", PREFIX+ "/users/{id}"),
+        ("DELETE", PREFIX+ "/users/{id}"),
+        ("PATCH", PREFIX+ "/users/{id}"),
+        ("POST", PREFIX+ "/auth/jwt/logout"),
+    }
+
+    IGNORED_PATHS = {
+        "/openapi.json"
+    }
+
+    # Checks if all routes are classified and makes sure that new routes must be protected or ex
+    def test_all_routes_are_classified(self):
+        app_routes = set()
+
+        for route in app.routes:
+            if not hasattr(route, "methods"):
+                continue
+
+            for method in route.methods:
+                if method in {"HEAD", "OPTIONS"}:
+                    continue
+
+                if route.path in self.IGNORED_PATHS:
+                    continue
+
+                app_routes.add((method, route.path))
+
+        classified_routes = self.PUBLIC_ENDPOINTS | self.PROTECTED_ENDPOINTS
+
+        unclassified = app_routes - classified_routes
+
+        assert not unclassified, (
+            "Every route must be classified as public or protected. "
+            f"Unclassified routes: {unclassified}"
+        )

--- a/backend/tests/test_pentest.py
+++ b/backend/tests/test_pentest.py
@@ -1,7 +1,12 @@
+from httpx import AsyncClient
+
 from app.main import app
 
+import pytest
+PREFIX = "/api/v0"
+
 class TestRouteClassification:
-    PREFIX = "/api/v0"
+
 
     PUBLIC_ENDPOINTS = {
         ("GET", "/"),
@@ -60,4 +65,174 @@ class TestRouteClassification:
         assert not unclassified, (
             "Every route must be classified as public or protected. "
             f"Unclassified routes: {unclassified}"
+        )
+
+class TestStationsAuth:
+    @pytest.mark.asyncio
+    async def test_list_stations_requires_auth(self, async_client: AsyncClient):
+        response = await async_client.get( f"{PREFIX}/stations/")
+
+        assert response.status_code in (401, 403), (
+            f"GET {PREFIX}/stations/ must not be accessible without authentication"
+        )
+
+    @pytest.mark.asyncio
+    async def test_nearby_stations_requires_auth(self, async_client: AsyncClient):
+        response = await async_client.get(
+            f"{PREFIX}/stations/nearby",
+            params={
+                "latitude": 48.1351,
+                "longitude": 11.5820,
+            },
+        )
+
+        assert response.status_code in (401, 403), (
+            f"GET {PREFIX}/stations/nearby must not be accessible without authentication"
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_stations_rejects_invalid_bearer_token(self, async_client: AsyncClient):
+        response = await async_client.get(
+            f"{PREFIX}/stations/",
+            headers={"Authorization": "Bearer invalid-token"},
+        )
+
+        assert response.status_code in (401, 403), (
+            f"GET {PREFIX}/stations/ must reject invalid authentication tokens"
+        )
+
+    @pytest.mark.asyncio
+    async def test_nearby_stations_rejects_invalid_bearer_token(self, async_client: AsyncClient):
+        response = await async_client.get(
+            f"{PREFIX}/stations/nearby",
+            params={
+                "latitude": 48.1351,
+                "longitude": 11.5820,
+            },
+            headers={"Authorization": "Bearer invalid-token"},
+        )
+
+        assert response.status_code in (401, 403), (
+            f"GET {PREFIX}/stations/nearby must reject invalid authentication tokens"
+        )
+
+class TestExportAuth:
+    @pytest.mark.asyncio
+    async def test_export_json_requires_auth(self, async_client: AsyncClient):
+        response = await async_client.get(f"{PREFIX}/export/json")
+
+        assert response.status_code in (401, 403), (
+            f"GET {PREFIX}/export/json must not be accessible without authentication"
+        )
+
+    @pytest.mark.asyncio
+    async def test_export_csv_requires_auth(self, async_client: AsyncClient):
+        response = await async_client.get(f"{PREFIX}/export/csv")
+
+        assert response.status_code in (401, 403), (
+            f"GET {PREFIX}/export/csv must not be accessible without authentication"
+        )
+
+    @pytest.mark.asyncio
+    async def test_export_json_rejects_invalid_bearer_token(self, async_client: AsyncClient):
+        response = await async_client.get(
+            f"{PREFIX}/export/json",
+            headers={"Authorization": "Bearer invalid-token"},
+        )
+
+        assert response.status_code in (401, 403), (
+            f"GET {PREFIX}/export/json must reject invalid authentication tokens"
+        )
+
+    @pytest.mark.asyncio
+    async def test_export_csv_rejects_invalid_bearer_token(self, async_client: AsyncClient):
+        response = await async_client.get(
+            f"{PREFIX}/export/csv",
+            headers={"Authorization": "Bearer invalid-token"},
+        )
+
+        assert response.status_code in (401, 403), (
+            f"GET {PREFIX}/export/csv must reject invalid authentication tokens"
+        )
+
+class TestFillingsAuth:
+    @pytest.mark.asyncio
+    async def test_create_filling_requires_auth(self, async_client: AsyncClient):
+        response = await async_client.post(
+            f"{PREFIX}/fillings/create",
+            json={
+                "license_plate_number": "M-AB-1234",
+                "mileage": 10000,
+                "price_per_litre": 1.75,
+                "litres": 40.0,
+                "total_price": 70.0,
+                "fuel_type": "diesel",
+                "tankerkoenig_station_id": "station-123",
+            },
+        )
+
+        assert response.status_code in (401, 403), (
+            f"POST {PREFIX}/fillings/create must not be accessible without authentication"
+        )
+
+    @pytest.mark.asyncio
+    async def test_delete_filling_requires_auth(self, async_client: AsyncClient):
+        response = await async_client.delete(
+            f"{PREFIX}/fillings/delete",
+            params={"filling_id": 1},
+        )
+
+        assert response.status_code in (401, 403), (
+            f"DELETE {PREFIX}/fillings/delete must not be accessible without authentication"
+        )
+
+    @pytest.mark.asyncio
+    async def test_get_fillings_requires_auth(self, async_client: AsyncClient):
+        response = await async_client.get(f"{PREFIX}/fillings")
+
+        assert response.status_code in (401, 403), (
+            f"GET {PREFIX}/fillings must not be accessible without authentication"
+        )
+
+    @pytest.mark.asyncio
+    async def test_create_filling_rejects_invalid_bearer_token(self, async_client: AsyncClient):
+        response = await async_client.post(
+            f"{PREFIX}/fillings/create",
+            json={
+                "license_plate_number": "M-AB-1234",
+                "mileage": 10000,
+                "price_per_litre": 1.75,
+                "litres": 40.0,
+                "total_price": 70.0,
+                "fuel_type": "diesel",
+                "tankerkoenig_station_id": "station-123",
+            },
+            headers={"Authorization": "Bearer invalid-token"},
+        )
+
+        assert response.status_code in (401, 403), (
+            f"POST {PREFIX}/fillings/create must reject invalid authentication tokens"
+        )
+
+    @pytest.mark.asyncio
+    async def test_delete_filling_rejects_invalid_bearer_token(self, async_client: AsyncClient):
+        response = await async_client.delete(
+            f"{PREFIX}/fillings/delete",
+            params={"filling_id": 1},
+            headers={"Authorization": "Bearer invalid-token"},
+        )
+
+        assert response.status_code in (401, 403), (
+            f"DELETE {PREFIX}/fillings/delete must reject invalid authentication tokens"
+        )
+
+    @pytest.mark.asyncio
+    async def test_get_fillings_rejects_invalid_bearer_token(self, async_client: AsyncClient):
+        response = await async_client.get(
+            f"{PREFIX}/fillings",
+            headers={"Authorization": "Bearer invalid-token"},
+        )
+
+        assert response.status_code in (401, 403), (
+            f"GET {PREFIX}/fillings must reject invalid authentication tokens"
         )

--- a/backend/tests/test_pentest.py
+++ b/backend/tests/test_pentest.py
@@ -3,236 +3,228 @@ from httpx import AsyncClient
 from app.main import app
 
 import pytest
+
 PREFIX = "/api/v0"
 
+
 class TestRouteClassification:
+	PUBLIC_ENDPOINTS = {
+		("GET", "/"),
+		("GET", "/redoc"),
+		("GET", "/docs"),
+		("GET", "/health"),
+		("GET", PREFIX + "/auth"),
+		("POST", PREFIX + "/auth/register"),
+		("POST", PREFIX + "/auth/jwt/login"),
+		("POST", PREFIX + "/auth/jwt/register"),
+		("GET", PREFIX + "/docs"),
+		("GET", "/docs/oauth2-redirect"),
+	}
 
+	PROTECTED_ENDPOINTS = {
+		("GET", PREFIX + "/export/json"),
+		("GET", PREFIX + "/export/csv"),
+		("GET", PREFIX + "/fillings"),
+		("POST", PREFIX + "/fillings/create"),
+		("DELETE", PREFIX + "/fillings/delete"),
+		("GET", PREFIX + "/stations/"),
+		("GET", PREFIX + "/stations/nearby"),
+		("GET", PREFIX + "/users/me"),
+		("PATCH", PREFIX + "/users/me"),
+		("GET", PREFIX + "/users/{id}"),
+		("DELETE", PREFIX + "/users/{id}"),
+		("PATCH", PREFIX + "/users/{id}"),
+		("POST", PREFIX + "/auth/jwt/logout"),
+	}
 
-    PUBLIC_ENDPOINTS = {
-        ("GET", "/"),
-        ("GET", "/redoc"),
-        ("GET", "/docs"),
-        ("GET", "/health"),
-        ("GET", PREFIX+ "/auth"),
-        ("POST", PREFIX+ "/auth/register"),
-        ("POST", PREFIX+ "/auth/jwt/login"),
-        ("POST", PREFIX+ "/auth/jwt/register"),
-        ("GET", PREFIX+ "/docs"),
-        ("GET", "/docs/oauth2-redirect"),
-    }
+	IGNORED_PATHS = {"/openapi.json"}
 
-    PROTECTED_ENDPOINTS = {
-        ("GET", PREFIX+ "/export/json"),
-        ("GET", PREFIX+ "/export/csv"),
-        ("GET", PREFIX+ "/fillings"),
-        ("POST", PREFIX+ "/fillings/create"),
-        ("DELETE", PREFIX+ "/fillings/delete"),
-        ("GET", PREFIX+ "/stations/"),
-        ("GET", PREFIX+ "/stations/nearby"),
-        ("GET", PREFIX+ "/users/me"),
-        ("PATCH", PREFIX+ "/users/me"),
-        ("GET", PREFIX+ "/users/{id}"),
-        ("DELETE", PREFIX+ "/users/{id}"),
-        ("PATCH", PREFIX+ "/users/{id}"),
-        ("POST", PREFIX+ "/auth/jwt/logout"),
-    }
+	# Checks if all routes are classified and makes sure that new routes must be protected or ex
+	def test_all_routes_are_classified(self):
+		app_routes = set()
 
-    IGNORED_PATHS = {
-        "/openapi.json"
-    }
+		for route in app.routes:
+			if not hasattr(route, "methods"):
+				continue
 
-    # Checks if all routes are classified and makes sure that new routes must be protected or ex
-    def test_all_routes_are_classified(self):
-        app_routes = set()
+			for method in route.methods:
+				if method in {"HEAD", "OPTIONS"}:
+					continue
 
-        for route in app.routes:
-            if not hasattr(route, "methods"):
-                continue
+				if route.path in self.IGNORED_PATHS:
+					continue
 
-            for method in route.methods:
-                if method in {"HEAD", "OPTIONS"}:
-                    continue
+				app_routes.add((method, route.path))
 
-                if route.path in self.IGNORED_PATHS:
-                    continue
+		classified_routes = self.PUBLIC_ENDPOINTS | self.PROTECTED_ENDPOINTS
 
-                app_routes.add((method, route.path))
+		unclassified = app_routes - classified_routes
 
-        classified_routes = self.PUBLIC_ENDPOINTS | self.PROTECTED_ENDPOINTS
+		assert not unclassified, (
+			f"Every route must be classified as public or protected. Unclassified routes: {unclassified}"
+		)
 
-        unclassified = app_routes - classified_routes
-
-        assert not unclassified, (
-            "Every route must be classified as public or protected. "
-            f"Unclassified routes: {unclassified}"
-        )
 
 class TestStationsAuth:
-    @pytest.mark.asyncio
-    async def test_list_stations_requires_auth(self, async_client: AsyncClient):
-        response = await async_client.get( f"{PREFIX}/stations/")
+	@pytest.mark.asyncio
+	async def test_list_stations_requires_auth(self, async_client: AsyncClient):
+		response = await async_client.get(f"{PREFIX}/stations/")
 
-        assert response.status_code in (401, 403), (
-            f"GET {PREFIX}/stations/ must not be accessible without authentication"
-        )
+		assert response.status_code in (401, 403), (
+			f"GET {PREFIX}/stations/ must not be accessible without authentication"
+		)
 
-    @pytest.mark.asyncio
-    async def test_nearby_stations_requires_auth(self, async_client: AsyncClient):
-        response = await async_client.get(
-            f"{PREFIX}/stations/nearby",
-            params={
-                "latitude": 48.1351,
-                "longitude": 11.5820,
-            },
-        )
+	@pytest.mark.asyncio
+	async def test_nearby_stations_requires_auth(self, async_client: AsyncClient):
+		response = await async_client.get(
+			f"{PREFIX}/stations/nearby",
+			params={
+				"latitude": 48.1351,
+				"longitude": 11.5820,
+			},
+		)
 
-        assert response.status_code in (401, 403), (
-            f"GET {PREFIX}/stations/nearby must not be accessible without authentication"
-        )
+		assert response.status_code in (401, 403), (
+			f"GET {PREFIX}/stations/nearby must not be accessible without authentication"
+		)
 
-    @pytest.mark.asyncio
-    async def test_list_stations_rejects_invalid_bearer_token(self, async_client: AsyncClient):
-        response = await async_client.get(
-            f"{PREFIX}/stations/",
-            headers={"Authorization": "Bearer invalid-token"},
-        )
+	@pytest.mark.asyncio
+	async def test_list_stations_rejects_invalid_bearer_token(self, async_client: AsyncClient):
+		response = await async_client.get(
+			f"{PREFIX}/stations/",
+			headers={"Authorization": "Bearer invalid-token"},
+		)
 
-        assert response.status_code in (401, 403), (
-            f"GET {PREFIX}/stations/ must reject invalid authentication tokens"
-        )
+		assert response.status_code in (401, 403), f"GET {PREFIX}/stations/ must reject invalid authentication tokens"
 
-    @pytest.mark.asyncio
-    async def test_nearby_stations_rejects_invalid_bearer_token(self, async_client: AsyncClient):
-        response = await async_client.get(
-            f"{PREFIX}/stations/nearby",
-            params={
-                "latitude": 48.1351,
-                "longitude": 11.5820,
-            },
-            headers={"Authorization": "Bearer invalid-token"},
-        )
+	@pytest.mark.asyncio
+	async def test_nearby_stations_rejects_invalid_bearer_token(self, async_client: AsyncClient):
+		response = await async_client.get(
+			f"{PREFIX}/stations/nearby",
+			params={
+				"latitude": 48.1351,
+				"longitude": 11.5820,
+			},
+			headers={"Authorization": "Bearer invalid-token"},
+		)
 
-        assert response.status_code in (401, 403), (
-            f"GET {PREFIX}/stations/nearby must reject invalid authentication tokens"
-        )
+		assert response.status_code in (401, 403), (
+			f"GET {PREFIX}/stations/nearby must reject invalid authentication tokens"
+		)
+
 
 class TestExportAuth:
-    @pytest.mark.asyncio
-    async def test_export_json_requires_auth(self, async_client: AsyncClient):
-        response = await async_client.get(f"{PREFIX}/export/json")
+	@pytest.mark.asyncio
+	async def test_export_json_requires_auth(self, async_client: AsyncClient):
+		response = await async_client.get(f"{PREFIX}/export/json")
 
-        assert response.status_code in (401, 403), (
-            f"GET {PREFIX}/export/json must not be accessible without authentication"
-        )
+		assert response.status_code in (401, 403), (
+			f"GET {PREFIX}/export/json must not be accessible without authentication"
+		)
 
-    @pytest.mark.asyncio
-    async def test_export_csv_requires_auth(self, async_client: AsyncClient):
-        response = await async_client.get(f"{PREFIX}/export/csv")
+	@pytest.mark.asyncio
+	async def test_export_csv_requires_auth(self, async_client: AsyncClient):
+		response = await async_client.get(f"{PREFIX}/export/csv")
 
-        assert response.status_code in (401, 403), (
-            f"GET {PREFIX}/export/csv must not be accessible without authentication"
-        )
+		assert response.status_code in (401, 403), (
+			f"GET {PREFIX}/export/csv must not be accessible without authentication"
+		)
 
-    @pytest.mark.asyncio
-    async def test_export_json_rejects_invalid_bearer_token(self, async_client: AsyncClient):
-        response = await async_client.get(
-            f"{PREFIX}/export/json",
-            headers={"Authorization": "Bearer invalid-token"},
-        )
+	@pytest.mark.asyncio
+	async def test_export_json_rejects_invalid_bearer_token(self, async_client: AsyncClient):
+		response = await async_client.get(
+			f"{PREFIX}/export/json",
+			headers={"Authorization": "Bearer invalid-token"},
+		)
 
-        assert response.status_code in (401, 403), (
-            f"GET {PREFIX}/export/json must reject invalid authentication tokens"
-        )
+		assert response.status_code in (401, 403), f"GET {PREFIX}/export/json must reject invalid authentication tokens"
 
-    @pytest.mark.asyncio
-    async def test_export_csv_rejects_invalid_bearer_token(self, async_client: AsyncClient):
-        response = await async_client.get(
-            f"{PREFIX}/export/csv",
-            headers={"Authorization": "Bearer invalid-token"},
-        )
+	@pytest.mark.asyncio
+	async def test_export_csv_rejects_invalid_bearer_token(self, async_client: AsyncClient):
+		response = await async_client.get(
+			f"{PREFIX}/export/csv",
+			headers={"Authorization": "Bearer invalid-token"},
+		)
 
-        assert response.status_code in (401, 403), (
-            f"GET {PREFIX}/export/csv must reject invalid authentication tokens"
-        )
+		assert response.status_code in (401, 403), f"GET {PREFIX}/export/csv must reject invalid authentication tokens"
+
 
 class TestFillingsAuth:
-    @pytest.mark.asyncio
-    async def test_create_filling_requires_auth(self, async_client: AsyncClient):
-        response = await async_client.post(
-            f"{PREFIX}/fillings/create",
-            json={
-                "license_plate_number": "M-AB-1234",
-                "mileage": 10000,
-                "price_per_litre": 1.75,
-                "litres": 40.0,
-                "total_price": 70.0,
-                "fuel_type": "diesel",
-                "tankerkoenig_station_id": "station-123",
-            },
-        )
+	@pytest.mark.asyncio
+	async def test_create_filling_requires_auth(self, async_client: AsyncClient):
+		response = await async_client.post(
+			f"{PREFIX}/fillings/create",
+			json={
+				"license_plate_number": "M-AB-1234",
+				"mileage": 10000,
+				"price_per_litre": 1.75,
+				"litres": 40.0,
+				"total_price": 70.0,
+				"fuel_type": "diesel",
+				"tankerkoenig_station_id": "station-123",
+			},
+		)
 
-        assert response.status_code in (401, 403), (
-            f"POST {PREFIX}/fillings/create must not be accessible without authentication"
-        )
+		assert response.status_code in (401, 403), (
+			f"POST {PREFIX}/fillings/create must not be accessible without authentication"
+		)
 
-    @pytest.mark.asyncio
-    async def test_delete_filling_requires_auth(self, async_client: AsyncClient):
-        response = await async_client.delete(
-            f"{PREFIX}/fillings/delete",
-            params={"filling_id": 1},
-        )
+	@pytest.mark.asyncio
+	async def test_delete_filling_requires_auth(self, async_client: AsyncClient):
+		response = await async_client.delete(
+			f"{PREFIX}/fillings/delete",
+			params={"filling_id": 1},
+		)
 
-        assert response.status_code in (401, 403), (
-            f"DELETE {PREFIX}/fillings/delete must not be accessible without authentication"
-        )
+		assert response.status_code in (401, 403), (
+			f"DELETE {PREFIX}/fillings/delete must not be accessible without authentication"
+		)
 
-    @pytest.mark.asyncio
-    async def test_get_fillings_requires_auth(self, async_client: AsyncClient):
-        response = await async_client.get(f"{PREFIX}/fillings")
+	@pytest.mark.asyncio
+	async def test_get_fillings_requires_auth(self, async_client: AsyncClient):
+		response = await async_client.get(f"{PREFIX}/fillings")
 
-        assert response.status_code in (401, 403), (
-            f"GET {PREFIX}/fillings must not be accessible without authentication"
-        )
+		assert response.status_code in (401, 403), (
+			f"GET {PREFIX}/fillings must not be accessible without authentication"
+		)
 
-    @pytest.mark.asyncio
-    async def test_create_filling_rejects_invalid_bearer_token(self, async_client: AsyncClient):
-        response = await async_client.post(
-            f"{PREFIX}/fillings/create",
-            json={
-                "license_plate_number": "M-AB-1234",
-                "mileage": 10000,
-                "price_per_litre": 1.75,
-                "litres": 40.0,
-                "total_price": 70.0,
-                "fuel_type": "diesel",
-                "tankerkoenig_station_id": "station-123",
-            },
-            headers={"Authorization": "Bearer invalid-token"},
-        )
+	@pytest.mark.asyncio
+	async def test_create_filling_rejects_invalid_bearer_token(self, async_client: AsyncClient):
+		response = await async_client.post(
+			f"{PREFIX}/fillings/create",
+			json={
+				"license_plate_number": "M-AB-1234",
+				"mileage": 10000,
+				"price_per_litre": 1.75,
+				"litres": 40.0,
+				"total_price": 70.0,
+				"fuel_type": "diesel",
+				"tankerkoenig_station_id": "station-123",
+			},
+			headers={"Authorization": "Bearer invalid-token"},
+		)
 
-        assert response.status_code in (401, 403), (
-            f"POST {PREFIX}/fillings/create must reject invalid authentication tokens"
-        )
+		assert response.status_code in (401, 403), (
+			f"POST {PREFIX}/fillings/create must reject invalid authentication tokens"
+		)
 
-    @pytest.mark.asyncio
-    async def test_delete_filling_rejects_invalid_bearer_token(self, async_client: AsyncClient):
-        response = await async_client.delete(
-            f"{PREFIX}/fillings/delete",
-            params={"filling_id": 1},
-            headers={"Authorization": "Bearer invalid-token"},
-        )
+	@pytest.mark.asyncio
+	async def test_delete_filling_rejects_invalid_bearer_token(self, async_client: AsyncClient):
+		response = await async_client.delete(
+			f"{PREFIX}/fillings/delete",
+			params={"filling_id": 1},
+			headers={"Authorization": "Bearer invalid-token"},
+		)
 
-        assert response.status_code in (401, 403), (
-            f"DELETE {PREFIX}/fillings/delete must reject invalid authentication tokens"
-        )
+		assert response.status_code in (401, 403), (
+			f"DELETE {PREFIX}/fillings/delete must reject invalid authentication tokens"
+		)
 
-    @pytest.mark.asyncio
-    async def test_get_fillings_rejects_invalid_bearer_token(self, async_client: AsyncClient):
-        response = await async_client.get(
-            f"{PREFIX}/fillings",
-            headers={"Authorization": "Bearer invalid-token"},
-        )
+	@pytest.mark.asyncio
+	async def test_get_fillings_rejects_invalid_bearer_token(self, async_client: AsyncClient):
+		response = await async_client.get(
+			f"{PREFIX}/fillings",
+			headers={"Authorization": "Bearer invalid-token"},
+		)
 
-        assert response.status_code in (401, 403), (
-            f"GET {PREFIX}/fillings must reject invalid authentication tokens"
-        )
+		assert response.status_code in (401, 403), f"GET {PREFIX}/fillings must reject invalid authentication tokens"

--- a/docs/arc42/08_crosscutting_concepts.md
+++ b/docs/arc42/08_crosscutting_concepts.md
@@ -208,7 +208,9 @@ As integration tests are on a higher level than unit tests they combine differen
 Integration tests are part of the automated CI tests suite. 
 
 ### 8.10.5 E2E Tests
-The End-to-End Tests are created with a tool called Playwright. Playwright enables us to automatically test the front end of our application via its chromium based browser.
+The End-to-End Tests are created with a tool called Playwright. Playwright enables us to automatically test the front end of our application via its chromium based browser. The browser is instructed to navigate through the frontend like a user would. Playwright then tests, if it behaves accordingly.
+To be independent of the backend, the backend is mocked. For each page we load the page and check, if the page contains the expected html response results.
+The results are checked based on so called "selectors".
 
 ### 8.10.6 Smoke Tests
 A smoke test verifies that the application starts up and is reachable. The tests suite contains smoke tests for the gas station service to check the ongoing compatibility with the Tankerkönig API.

--- a/docs/arc42/08_crosscutting_concepts.md
+++ b/docs/arc42/08_crosscutting_concepts.md
@@ -213,6 +213,16 @@ The End-to-End Tests are created with a tool called Playwright. Playwright enabl
 ### 8.10.6 Smoke Tests
 A smoke test verifies that the application starts up and is reachable. The tests suite contains smoke tests for the gas station service to check the ongoing compatibility with the Tankerkönig API.
 
+### 8.10.7 Penetration Tests
+The backend penetration test strategy focuses on verifying the correct enforcement of authentication for all protected FastAPI endpoints. Since the application exposes user-specific and security-relevant data, such as fuel history records, exported user data, and station-related information, every non-public endpoint must reject requests that are not associated with a valid authenticated user. The main goal of these tests is therefore to ensure that no protected route can be accessed anonymously or with invalid credentials.
+
+The implemented tests follow a lightweight but systematic approach. For each protected endpoint, an automated pytest test sends a request without an `Authorization` header and expects the backend to respond with either `401 Unauthorized` or `403 Forbidden`. A second test sends the same request with a malformed or invalid bearer token and again verifies that access is denied. Where an endpoint requires query parameters or a request body, the tests provide valid example input so that validation errors cannot hide authentication problems. This ensures that a successful response would clearly indicate a broken authentication check.
+
+The actual backend test classes are grouped by router in the `test_pentest.py` file. The tests are intended to run as part of the automated test suite and CI pipeline, so newly introduced regressions in authentication behavior are detected early before deployment. 
+
+The test suite also flags any new and unclassified endpoints by iterating over all available endpoints. The project group agreed that every new endpoint must be classified and that the necessary tests must be developed if it is a protected endpoint.
+
+
 ### 8.10.7 Architecture Tests
 Architecture tests ensure that certain namespaces are not allowed to import or use another namespace. This enforces separation of concerns and promotes modularity and abstraction. 
 


### PR DESCRIPTION
# Pull Request

Fixes #248

## Description

All endpoints are now auto-classified and pen tested if they require authentication. 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Checklist
- [x] Code compiles
- [x] No new warnings added to code base
- [x] Existing tests are green
- [x] Tests added
- [x] Code is commented where necessary
- [x] Documentation updated